### PR TITLE
Add supporters

### DIFF
--- a/lib/bearings/account/account.ex
+++ b/lib/bearings/account/account.ex
@@ -111,4 +111,100 @@ defmodule Bearings.Account do
   def change_user(%User{} = user) do
     User.changeset(user, %{})
   end
+
+  alias Bearings.Account.Supporter
+
+  @doc """
+  Returns the list of supporters.
+
+  ## Examples
+
+      iex> list_supporters()
+      [%Supporter{}, ...]
+
+  """
+  def list_supporters do
+    Repo.all(Supporter)
+  end
+
+  @doc """
+  Gets a single supporter.
+
+  Raises `Ecto.NoResultsError` if the Supporter does not exist.
+
+  ## Examples
+
+      iex> get_supporter!(123)
+      %Supporter{}
+
+      iex> get_supporter!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_supporter!(id), do: Repo.get!(Supporter, id)
+
+  @doc """
+  Creates a supporter.
+
+  ## Examples
+
+      iex> create_supporter(%{field: value})
+      {:ok, %Supporter{}}
+
+      iex> create_supporter(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_supporter(attrs \\ %{}) do
+    %Supporter{}
+    |> Supporter.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a supporter.
+
+  ## Examples
+
+      iex> update_supporter(supporter, %{field: new_value})
+      {:ok, %Supporter{}}
+
+      iex> update_supporter(supporter, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_supporter(%Supporter{} = supporter, attrs) do
+    supporter
+    |> Supporter.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Supporter.
+
+  ## Examples
+
+      iex> delete_supporter(supporter)
+      {:ok, %Supporter{}}
+
+      iex> delete_supporter(supporter)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_supporter(%Supporter{} = supporter) do
+    Repo.delete(supporter)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking supporter changes.
+
+  ## Examples
+
+      iex> change_supporter(supporter)
+      %Ecto.Changeset{source: %Supporter{}}
+
+  """
+  def change_supporter(%Supporter{} = supporter) do
+    Supporter.changeset(supporter, %{})
+  end
 end

--- a/lib/bearings/account/account.ex
+++ b/lib/bearings/account/account.ex
@@ -143,6 +143,13 @@ defmodule Bearings.Account do
   """
   def get_supporter!(id), do: Repo.get!(Supporter, id)
 
+  def find_supporter(supporter: %User{id: supporter_id}, owner_username: owner_username) do
+    Supporter
+    |> join(:inner, [s], u in assoc(s, :user))
+    |> where([s, u], s.supporter_id == ^supporter_id and u.github_login == ^owner_username)
+    |> Repo.one()
+  end
+
   @doc """
   Creates a supporter.
 

--- a/lib/bearings/account/supporter.ex
+++ b/lib/bearings/account/supporter.ex
@@ -1,13 +1,17 @@
 defmodule Bearings.Account.Supporter do
+  @moduledoc """
+  Struct and functions to repesent supporters.
+  """
+
   use Ecto.Schema
   import Ecto.Changeset
 
   alias Bearings.Account.User
 
   schema "supporters" do
-    belongs_to :user, User
-    belongs_to :supporter, User
-    field :accountable, :boolean, default: false
+    belongs_to(:user, User)
+    belongs_to(:supporter, User)
+    field(:accountable, :boolean, default: false)
 
     timestamps()
   end

--- a/lib/bearings/account/supporter.ex
+++ b/lib/bearings/account/supporter.ex
@@ -1,0 +1,21 @@
+defmodule Bearings.Account.Supporter do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Bearings.Account.User
+
+  schema "supporters" do
+    belongs_to :user, User
+    belongs_to :supporter, User
+    field :accountable, :boolean, default: false
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(supporter, attrs) do
+    supporter
+    |> cast(attrs, [:user_id, :supporter_id, :accountable])
+    |> validate_required([:user_id, :supporter_id, :accountable])
+  end
+end

--- a/lib/bearings/dailies/dailies.ex
+++ b/lib/bearings/dailies/dailies.ex
@@ -6,6 +6,7 @@ defmodule Bearings.Dailies do
   import Ecto.Query, warn: false
   alias Bearings.Repo
 
+  alias Bearings.Account.User
   alias Bearings.Dailies.Daily
 
   @doc """
@@ -17,9 +18,10 @@ defmodule Bearings.Dailies do
       [%Daily{}, ...]
 
   """
-  def list_dailies(owner_id) do
+  def list_dailies(username) do
     Daily
-    |> where(owner_id: ^owner_id)
+    |> join(:inner, [d], o in User, o.id == d.owner_id)
+    |> where([_d, o], o.github_login == ^username)
     |> Repo.all()
   end
 
@@ -38,6 +40,14 @@ defmodule Bearings.Dailies do
 
   """
   def get_daily!(id), do: Repo.get!(Daily, id)
+
+  def get_daily!(id, username) do
+    Daily
+    |> join(:inner, [d], o in User, o.id == d.owner_id)
+    |> where([d], d.id == ^id)
+    |> where([_d, o], o.github_login == ^username)
+    |> Repo.one()
+  end
 
   @doc """
   Creates a daily.

--- a/lib/bearings/dailies/daily.ex
+++ b/lib/bearings/dailies/daily.ex
@@ -23,6 +23,10 @@ defmodule Bearings.Dailies.Daily do
     timestamps()
   end
 
+  def strip_private_markdown(%__MODULE__{} = daily) do
+    %{daily | private_markdown: nil}
+  end
+
   @doc false
   def changeset(daily, attrs) do
     daily

--- a/lib/bearings_web/account/user.ex
+++ b/lib/bearings_web/account/user.ex
@@ -1,0 +1,5 @@
+defimpl Phoenix.Param, for: Bearings.Account.User do
+  def to_param(%{github_login: username}) do
+    username
+  end
+end

--- a/lib/bearings_web/controllers/daily_controller.ex
+++ b/lib/bearings_web/controllers/daily_controller.ex
@@ -10,7 +10,7 @@ defmodule BearingsWeb.DailyController do
     apply(__MODULE__, action_name(conn), [conn, conn.params, conn.assigns.current_user])
   end
 
-  def create(conn, %{"daily" => daily_params}, %{id: user_id}) do
+  def create(conn, %{"daily" => daily_params}, %{id: user_id} = user) do
     daily_params
     |> Map.put("owner_id", user_id)
     |> Dailies.create_daily()
@@ -18,7 +18,7 @@ defmodule BearingsWeb.DailyController do
       {:ok, daily} ->
         conn
         |> put_flash(:info, "Created Successfully")
-        |> redirect(to: daily_path(conn, :show, daily))
+        |> redirect(to: daily_path(conn, :show, user, daily))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
@@ -37,10 +37,6 @@ defmodule BearingsWeb.DailyController do
     render(conn, "index.html", dailies: dailies)
   end
 
-  def index(conn, _params, _) do
-    render(conn, "index.html", dailies: [])
-  end
-
   def new(conn, _params, _user) do
     changeset = Dailies.change_daily(%Daily{})
     render(conn, "new.html", changeset: changeset)
@@ -51,14 +47,14 @@ defmodule BearingsWeb.DailyController do
     render(conn, "show.html", daily: daily)
   end
 
-  def update(conn, %{"id" => id, "daily" => daily_params}, _user) do
+  def update(conn, %{"id" => id, "daily" => daily_params}, user) do
     daily = Dailies.get_daily!(id)
 
     case Dailies.update_daily(daily, daily_params) do
       {:ok, daily} ->
         conn
         |> put_flash(:info, "Updated Successfully")
-        |> redirect(to: daily_path(conn, :show, daily))
+        |> redirect(to: daily_path(conn, :show, user, daily))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html", changeset: changeset, daily: daily)

--- a/lib/bearings_web/controllers/daily_controller.ex
+++ b/lib/bearings_web/controllers/daily_controller.ex
@@ -1,18 +1,26 @@
 defmodule BearingsWeb.DailyController do
   use BearingsWeb, :controller
 
+  alias Bearings.Account
+  alias Bearings.Account.Supporter
   alias Bearings.Dailies
   alias Bearings.Dailies.Daily
 
-  plug(:authenticate when action in [:new, :create, :edit, :update])
+  plug(:authenticate)
+  plug(:authorize_owner when action in [:new, :create, :edit, :update, :delete])
+  plug(:authorize_supporter_or_owner when action in [:index, :show])
 
   def action(conn, _) do
-    apply(__MODULE__, action_name(conn), [conn, conn.params, conn.assigns.current_user])
+    apply(__MODULE__, action_name(conn), [
+      conn,
+      conn.params,
+      %{user: conn.assigns.current_user, supporter: conn.assigns[:supporter]}
+    ])
   end
 
-  def create(conn, %{"daily" => daily_params}, %{id: user_id} = user) do
+  def create(conn, %{"daily" => daily_params}, %{user: user}) do
     daily_params
-    |> Map.put("owner_id", user_id)
+    |> Map.put("owner_id", user.id)
     |> Dailies.create_daily()
     |> case do
       {:ok, daily} ->
@@ -32,22 +40,48 @@ defmodule BearingsWeb.DailyController do
     render(conn, "edit.html", changeset: changeset, daily: daily)
   end
 
-  def index(conn, _params, %{id: user_id}) do
-    dailies = Dailies.list_dailies(user_id)
+  def index(conn, %{"username" => username}, %{supporter: %Supporter{accountable: false}}) do
+    dailies =
+      username
+      |> Dailies.list_dailies()
+      |> Enum.map(&Daily.strip_private_markdown/1)
+
     render(conn, "index.html", dailies: dailies)
   end
 
-  def new(conn, _params, _user) do
+  def index(conn, %{"username" => username}, assigns) do
+    dailies =
+      username
+      |> Dailies.list_dailies()
+      |> Enum.map(fn daily -> maybe_strip_private(daily, assigns) end)
+
+    render(conn, "index.html", dailies: dailies)
+  end
+
+  def new(conn, _params, _) do
     changeset = Dailies.change_daily(%Daily{})
     render(conn, "new.html", changeset: changeset)
   end
 
-  def show(conn, %{"id" => id}, _user) do
+  def show(conn, %{"id" => id, "username" => username}, assigns) do
+    id
+    |> Dailies.get_daily!(username)
+    |> case do
+      %Daily{} = daily ->
+        daily = maybe_strip_private(daily, assigns)
+        render(conn, "show.html", daily: daily)
+
+      nil ->
+        render(conn, BearingsWeb.ErrorView, "404.html")
+    end
+  end
+
+  def show(conn, %{"id" => id}, _) do
     daily = Dailies.get_daily!(id)
     render(conn, "show.html", daily: daily)
   end
 
-  def update(conn, %{"id" => id, "daily" => daily_params}, user) do
+  def update(conn, %{"id" => id, "daily" => daily_params}, %{user: user}) do
     daily = Dailies.get_daily!(id)
 
     case Dailies.update_daily(daily, daily_params) do
@@ -61,6 +95,23 @@ defmodule BearingsWeb.DailyController do
     end
   end
 
+  def delete(conn, params, %{user: user}) do
+    params["id"]
+    |> Dailies.get_daily!()
+    |> Dailies.delete_daily()
+    |> case do
+      {:ok, _} ->
+        conn
+        |> put_flash(:info, "Daily successfully deleted")
+        |> redirect(to: daily_path(conn, :index, user))
+
+      {:error, changeset} ->
+        conn
+        |> put_flash(:error, "Could not delete daily")
+        |> redirect(to: daily_path(conn, :index, user, changeset.id))
+    end
+  end
+
   defp authenticate(conn, _opts) do
     if conn.assigns.current_user do
       conn
@@ -71,4 +122,41 @@ defmodule BearingsWeb.DailyController do
       |> halt()
     end
   end
+
+  defp authorize_owner(conn, _opts) do
+    if conn.assigns.current_user.github_login == conn.params["username"] do
+      conn
+    else
+      conn
+      |> put_status(:not_found)
+      |> render(BearingsWeb.ErrorView, "404.html")
+      |> halt()
+    end
+  end
+
+  defp authorize_supporter_or_owner(conn, _opts) do
+    cond do
+      conn.assigns.current_user.github_login == conn.params["username"] ->
+        conn
+
+      supporter =
+          Account.find_supporter(
+            supporter: conn.assigns.current_user,
+            owner_username: conn.params["username"]
+          ) ->
+        assign(conn, :supporter, supporter)
+
+      true ->
+        conn
+        |> put_status(:not_found)
+        |> render(BearingsWeb.ErrorView, "404.html")
+        |> halt()
+    end
+  end
+
+  defp maybe_strip_private(daily, %{supporter: %Supporter{accountable: false}}) do
+    Daily.strip_private_markdown(daily)
+  end
+
+  defp maybe_strip_private(daily, _), do: daily
 end

--- a/lib/bearings_web/controllers/page_controller.ex
+++ b/lib/bearings_web/controllers/page_controller.ex
@@ -1,7 +1,15 @@
 defmodule BearingsWeb.PageController do
   use BearingsWeb, :controller
 
-  def index(conn, _params) do
-    redirect(conn, to: daily_path(conn, :index))
+  def action(conn, _) do
+    apply(__MODULE__, action_name(conn), [conn, conn.params, conn.assigns.current_user])
+  end
+
+  def index(conn, _params, nil) do
+    render(conn, "index.html")
+  end
+
+  def index(conn, _params, user) do
+    redirect(conn, to: daily_path(conn, :index, user))
   end
 end

--- a/lib/bearings_web/router.ex
+++ b/lib/bearings_web/router.ex
@@ -17,9 +17,15 @@ defmodule BearingsWeb.Router do
   scope "/", BearingsWeb do
     pipe_through(:browser)
 
-    resources("/dailies", DailyController)
+    # resources("/dailies", DailyController)
 
     get("/", PageController, :index)
+  end
+
+  scope "/:username", BearingsWeb do
+    pipe_through(:browser)
+
+    resources("/dailies", DailyController, as: :daily)
   end
 
   scope "/auth", BearingsWeb do

--- a/lib/bearings_web/templates/daily/edit.html.eex
+++ b/lib/bearings_web/templates/daily/edit.html.eex
@@ -1,4 +1,4 @@
 <div class="container daily-form">
   <h3 class="text-primary">Daily Goal Sheet</h3>
-  <%= render "form.html", Map.put(assigns, :action, daily_path(@conn, :update, @daily)) %>
+  <%= render "form.html", Map.put(assigns, :action, daily_path(@conn, :update, @conn.assigns.current_user, @daily)) %>
 </div>

--- a/lib/bearings_web/templates/daily/index.html.eex
+++ b/lib/bearings_web/templates/daily/index.html.eex
@@ -5,7 +5,7 @@
     <%= for daily <- @dailies do %>
       <div class="col-sm-3 daily-card" data-test="daily">
         <div class="bg-secondary">
-          <%= link daily.date, to: daily_path(@conn, :show, @conn.assigns.current_user, daily.id), class: "text-light" %>
+          <%= link daily.date, to: daily_path(@conn, :show, @conn.params["username"], daily.id), class: "text-light" %>
         </div>
         <div>Important stuff here</div>
       </div>
@@ -15,7 +15,11 @@
 
   <div class="row">
     <div class="col-sm-11 text-right">
-      <%= link "New", to: daily_path(@conn, :new, @conn.assigns.current_user), class: "btn btn-secondary" %>
+      <%= unless Map.has_key?(@conn.assigns, :supporter) do %>
+        <%= link "New", to: daily_path(@conn, :new, @conn.assigns.current_user), class: "btn btn-secondary" %>
+      <% else %>
+        <% inspect @conn.assigns.supporter %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/lib/bearings_web/templates/daily/index.html.eex
+++ b/lib/bearings_web/templates/daily/index.html.eex
@@ -3,9 +3,9 @@
 
   <div class="row">
     <%= for daily <- @dailies do %>
-      <div class="col-sm-3 daily-card">
+      <div class="col-sm-3 daily-card" data-test="daily">
         <div class="bg-secondary">
-          <%= link daily.date, to: daily_path(@conn, :show, daily.id), class: "text-light" %>
+          <%= link daily.date, to: daily_path(@conn, :show, @conn.assigns.current_user, daily.id), class: "text-light" %>
         </div>
         <div>Important stuff here</div>
       </div>
@@ -15,7 +15,7 @@
 
   <div class="row">
     <div class="col-sm-11 text-right">
-      <%= link "New", to: daily_path(@conn, :new), class: "btn btn-secondary" %>
+      <%= link "New", to: daily_path(@conn, :new, @conn.assigns.current_user), class: "btn btn-secondary" %>
     </div>
   </div>
 </div>

--- a/lib/bearings_web/templates/daily/new.html.eex
+++ b/lib/bearings_web/templates/daily/new.html.eex
@@ -1,3 +1,3 @@
 <h1>Plan a New Day</h1>
 
-<%= render "form.html", Map.put(assigns, :action, daily_path(@conn, :create)) %>
+<%= render "form.html", Map.put(assigns, :action, daily_path(@conn, :create, @conn.assigns.current_user)) %>

--- a/lib/bearings_web/templates/daily/show.html.eex
+++ b/lib/bearings_web/templates/daily/show.html.eex
@@ -16,7 +16,10 @@
 
   <div class="row daily-footer">
     <div class="col-sm text-right">
-      <%= link "Edit", to: daily_path(@conn, :edit, @conn.assigns.current_user, @daily.id), class: "btn btn-secondary" %>
+      <%= link "Back to List", to: daily_path(@conn, :index, @conn.params["username"]), class: "btn btn-secondary-outline" %>
+      <%= unless Map.has_key?(@conn.assigns, :supporter) do %>
+        <%= link "Edit", to: daily_path(@conn, :edit, @conn.params["username"], @daily.id), class: "btn btn-secondary" %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/lib/bearings_web/templates/daily/show.html.eex
+++ b/lib/bearings_web/templates/daily/show.html.eex
@@ -16,7 +16,7 @@
 
   <div class="row daily-footer">
     <div class="col-sm text-right">
-      <%= link "Edit", to: daily_path(@conn, :edit, @daily.id), class: "btn btn-secondary" %>
+      <%= link "Edit", to: daily_path(@conn, :edit, @conn.assigns.current_user, @daily.id), class: "btn btn-secondary" %>
     </div>
   </div>
 </div>

--- a/lib/bearings_web/templates/layout/app.html.eex
+++ b/lib/bearings_web/templates/layout/app.html.eex
@@ -21,13 +21,13 @@
         </button>
 
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-          <ul class="navbar-nav mr-auto">
-            <li class="nav-item active">
-              <%= link "Dailies", to: daily_path(@conn, :index), class: "nav-link" %>
-            </li>
-          </ul>
           <%= if @current_user do %>
             <ul class="navbar-nav right">
+              <ul class="navbar-nav mr-auto">
+                <li class="nav-item active">
+                  <%= link "Dailies", to: daily_path(@conn, :index, @conn.assigns.current_user), class: "nav-link" %>
+                </li>
+              </ul>
               <li class="nav-item dropdown">
 
                 <a class="nav-link active dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-test="current_user">

--- a/lib/bearings_web/views/markdown_helper.ex
+++ b/lib/bearings_web/views/markdown_helper.ex
@@ -6,6 +6,8 @@ defmodule BearingsWeb.MarkdownHelper do
   alias Bearings.Dailies.Markdown
   alias Phoenix.HTML
 
+  def to_html(nil), do: nil
+
   def to_html(%Markdown{raw: markdown}) do
     case Earmark.as_html(markdown) do
       {:ok, html, _} -> HTML.raw(html)

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Bearings.Mixfile do
       {:cowboy, "~> 1.0"},
       {:credo, "~> 0.9.1", only: [:dev, :test], runtime: false},
       {:earmark, "~> 1.2"},
-      {:ex_machina, "~> 2.2", only: :test},
+      {:ex_machina, "~> 2.2", only: [:dev, :test]},
       {:gettext, "~> 0.11"},
       {:oauth2, "~> 0.9.2"},
       {:phoenix, "~> 1.3.2"},

--- a/priv/repo/migrations/20180525024518_create_supporters.exs
+++ b/priv/repo/migrations/20180525024518_create_supporters.exs
@@ -1,0 +1,14 @@
+defmodule Bearings.Repo.Migrations.CreateSupporters do
+  use Ecto.Migration
+
+  def change do
+    create table(:supporters) do
+      add :user_id, :integer
+      add :supporter_id, :integer
+      add :accountable, :boolean, default: false, null: false
+
+      timestamps()
+    end
+
+  end
+end

--- a/test/bearings/account/account_test.exs
+++ b/test/bearings/account/account_test.exs
@@ -74,4 +74,68 @@ defmodule Bearings.AccountTest do
       assert %Ecto.Changeset{} = Account.change_user(user)
     end
   end
+
+  describe "supporters" do
+    alias Bearings.Account.Supporter
+
+    @valid_attrs %{accountable: true, supporter_id: 42, user_id: 42}
+    @update_attrs %{accountable: false, supporter_id: 43, user_id: 43}
+    @invalid_attrs %{accountable: nil, supporter_id: nil, user_id: nil}
+
+    def supporter_fixture(attrs \\ %{}) do
+      {:ok, supporter} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Account.create_supporter()
+
+      supporter
+    end
+
+    test "list_supporters/0 returns all supporters" do
+      supporter = supporter_fixture()
+      assert Account.list_supporters() == [supporter]
+    end
+
+    test "get_supporter!/1 returns the supporter with given id" do
+      supporter = supporter_fixture()
+      assert Account.get_supporter!(supporter.id) == supporter
+    end
+
+    test "create_supporter/1 with valid data creates a supporter" do
+      assert {:ok, %Supporter{} = supporter} = Account.create_supporter(@valid_attrs)
+      assert supporter.accountable == true
+      assert supporter.supporter_id == 42
+      assert supporter.user_id == 42
+    end
+
+    test "create_supporter/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Account.create_supporter(@invalid_attrs)
+    end
+
+    test "update_supporter/2 with valid data updates the supporter" do
+      supporter = supporter_fixture()
+      assert {:ok, supporter} = Account.update_supporter(supporter, @update_attrs)
+      assert %Supporter{} = supporter
+      assert supporter.accountable == false
+      assert supporter.supporter_id == 43
+      assert supporter.user_id == 43
+    end
+
+    test "update_supporter/2 with invalid data returns error changeset" do
+      supporter = supporter_fixture()
+      assert {:error, %Ecto.Changeset{}} = Account.update_supporter(supporter, @invalid_attrs)
+      assert supporter == Account.get_supporter!(supporter.id)
+    end
+
+    test "delete_supporter/1 deletes the supporter" do
+      supporter = supporter_fixture()
+      assert {:ok, %Supporter{}} = Account.delete_supporter(supporter)
+      assert_raise Ecto.NoResultsError, fn -> Account.get_supporter!(supporter.id) end
+    end
+
+    test "change_supporter/1 returns a supporter changeset" do
+      supporter = supporter_fixture()
+      assert %Ecto.Changeset{} = Account.change_supporter(supporter)
+    end
+  end
 end

--- a/test/bearings/dailies/dailies_test.exs
+++ b/test/bearings/dailies/dailies_test.exs
@@ -20,8 +20,9 @@ defmodule Bearings.DailiesTest do
     @invalid_attrs %{date: nil, private_markdown: nil, public_markdown: nil}
 
     test "list_dailies/0 returns all dailies" do
-      daily = insert(:daily)
-      assert Dailies.list_dailies(daily.owner_id) == [daily]
+      user = insert(:user)
+      daily = insert(:daily, owner_id: user.id)
+      assert Dailies.list_dailies(user.github_login) == [daily]
     end
 
     test "get_daily!/1 returns the daily with given id" do

--- a/test/bearings_web/controllers/daily_controller_test.exs
+++ b/test/bearings_web/controllers/daily_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule BearingsWeb.DailyControllerTest do
   use BearingsWeb.ConnCase
 
+  import BearingsWeb.Router.Helpers, only: [daily_path: 3, daily_path: 4]
+
   setup %{conn: conn} do
     user = insert(:user)
     conn = assign(conn, :current_user, user)
@@ -10,17 +12,171 @@ defmodule BearingsWeb.DailyControllerTest do
     {:ok, conn: conn, my_dailies: my_dailies, user: user}
   end
 
-  test "index", %{conn: conn, user: %{github_login: username}} do
-    conn = get(conn, "/#{username}/dailies")
+  describe "as owner" do
+    test "index", %{conn: conn, user: %{github_login: username}} do
+      conn = get(conn, "/#{username}/dailies")
 
-    assert 4 == length(conn.assigns.dailies)
+      assert 4 == length(conn.assigns.dailies)
+    end
+
+    test "create", %{conn: conn, user: %{github_login: username}} do
+      params = params_for(:daily, owner_id: nil)
+      conn = post(conn, "/#{username}/dailies", daily: params)
+
+      assert redirected_to(conn) =~ ~r[/dailies/\d+]
+      assert get_flash(conn, :info) != nil
+    end
+
+    test "show", %{conn: conn, user: user} do
+      daily = insert(:daily, owner_id: user.id)
+      conn = get(conn, daily_path(conn, :show, user, daily))
+
+      assert html_response(conn, 200)
+      assert conn.assigns.daily.id == daily.id
+    end
+
+    test "update", %{conn: conn, user: user} do
+      daily = insert(:daily, owner_id: user.id)
+      params = params_for(:daily, owner_id: nil)
+      conn = put(conn, daily_path(conn, :update, user, daily), daily: params)
+
+      assert redirected_to(conn) =~ ~r[/dailies/\d+]
+      assert get_flash(conn, :info) != nil
+    end
+
+    test "delete", %{conn: conn, user: user} do
+      daily = insert(:daily, owner_id: user.id)
+      conn = delete(conn, daily_path(conn, :update, user, daily))
+
+      assert redirected_to(conn) =~ ~r[/dailies]
+      assert get_flash(conn, :info) != nil
+    end
   end
 
-  test "create", %{conn: conn, user: %{github_login: username}} do
-    params = params_for(:daily, owner_id: nil)
-    conn = post(conn, "/#{username}/dailies", daily: params)
+  describe "as accountability partner" do
+    setup %{conn: conn, user: user} do
+      other = insert(:user)
+      insert(:supporter, supporter: user, user: other, accountable: true)
+      other_dailies = insert_list(4, :daily, owner_id: other.id)
 
-    assert redirected_to(conn) =~ ~r[/dailies/\d+]
-    assert get_flash(conn, :info) != nil
+      {:ok, conn: conn, other_user: other, other_dailies: other_dailies}
+    end
+
+    test "can see index with private markdown", %{
+      conn: conn,
+      other_user: %{github_login: username}
+    } do
+      conn = get(conn, "/#{username}/dailies")
+
+      assert 4 == length(conn.assigns.dailies)
+      assert hd(conn.assigns.dailies).private_markdown != nil
+    end
+
+    test "create", %{conn: conn, other_user: user} do
+      conn = post(conn, daily_path(conn, :create, user))
+      assert html_response(conn, 404)
+    end
+
+    test "show includes private section", %{conn: conn, other_user: user} do
+      daily = insert(:daily, owner_id: user.id)
+      conn = get(conn, daily_path(conn, :show, user, daily))
+
+      assert html_response(conn, 200)
+      assert conn.assigns.daily.id == daily.id
+      assert conn.assigns.daily.private_markdown != nil
+    end
+
+    test "cannot update a daily", %{conn: conn, other_user: user} do
+      other_daily = insert(:daily, owner_id: user.id)
+      conn = put(conn, daily_path(conn, :update, user, other_daily))
+      assert html_response(conn, 404)
+    end
+
+    test "cannot delete a daily", %{conn: conn, other_user: user} do
+      other_daily = insert(:daily, owner_id: user.id)
+      conn = delete(conn, daily_path(conn, :delete, user, other_daily))
+      assert html_response(conn, 404)
+    end
+  end
+
+  describe "as supporter" do
+    setup %{conn: conn, user: user} do
+      other = insert(:user)
+      insert(:supporter, supporter: user, user: other, accountable: false)
+      other_dailies = insert_list(4, :daily, owner_id: other.id)
+
+      {:ok, conn: conn, other_user: other, other_dailies: other_dailies}
+    end
+
+    test "can see index without private section", %{
+      conn: conn,
+      other_user: %{github_login: username}
+    } do
+      conn = get(conn, "/#{username}/dailies")
+
+      assert 4 == length(conn.assigns.dailies)
+      assert hd(conn.assigns.dailies).private_markdown == nil
+    end
+
+    test "create", %{conn: conn, other_user: user} do
+      conn = post(conn, daily_path(conn, :create, user))
+      assert html_response(conn, 404)
+    end
+
+    test "show without private section", %{conn: conn, other_user: user} do
+      daily = insert(:daily, owner_id: user.id)
+      conn = get(conn, daily_path(conn, :show, user, daily))
+
+      assert html_response(conn, 200)
+      assert conn.assigns.daily.id == daily.id
+      assert conn.assigns.daily.private_markdown == nil
+    end
+
+    test "cannot update a daily", %{conn: conn, other_user: user} do
+      other_daily = insert(:daily, owner_id: user.id)
+      conn = put(conn, daily_path(conn, :update, user, other_daily))
+      assert html_response(conn, 404)
+    end
+
+    test "cannot delete a daily", %{conn: conn, other_user: user} do
+      other_daily = insert(:daily, owner_id: user.id)
+      conn = delete(conn, daily_path(conn, :delete, user, other_daily))
+      assert html_response(conn, 404)
+    end
+  end
+
+  describe "with no supporter/accountability relationship" do
+    setup do
+      other = insert(:user)
+      insert_list(4, :daily, owner_id: other.id)
+      other_daily = insert(:daily, owner_id: other.id)
+
+      {:ok, other_user: other, other_daily: other_daily}
+    end
+
+    test "cannot see index", %{conn: conn, other_user: user} do
+      conn = get(conn, daily_path(conn, :index, user))
+      assert html_response(conn, 404)
+    end
+
+    test "cannot create", %{conn: conn, other_user: user} do
+      conn = post(conn, daily_path(conn, :create, user))
+      assert html_response(conn, 404)
+    end
+
+    test "cannot view a daily", %{conn: conn, other_user: user, other_daily: daily} do
+      conn = get(conn, daily_path(conn, :show, user, daily))
+      assert html_response(conn, 404)
+    end
+
+    test "cannot update a daily", %{conn: conn, other_user: user, other_daily: daily} do
+      conn = put(conn, daily_path(conn, :update, user, daily))
+      assert html_response(conn, 404)
+    end
+
+    test "cannot delete a daily", %{conn: conn, other_user: user, other_daily: daily} do
+      conn = delete(conn, daily_path(conn, :delete, user, daily))
+      assert html_response(conn, 404)
+    end
   end
 end

--- a/test/bearings_web/controllers/daily_controller_test.exs
+++ b/test/bearings_web/controllers/daily_controller_test.exs
@@ -10,15 +10,15 @@ defmodule BearingsWeb.DailyControllerTest do
     {:ok, conn: conn, my_dailies: my_dailies, user: user}
   end
 
-  test "index", %{conn: conn} do
-    conn = get(conn, "/dailies")
+  test "index", %{conn: conn, user: %{github_login: username}} do
+    conn = get(conn, "/#{username}/dailies")
 
     assert 4 == length(conn.assigns.dailies)
   end
 
-  test "create", %{conn: conn} do
+  test "create", %{conn: conn, user: %{github_login: username}} do
     params = params_for(:daily, owner_id: nil)
-    conn = post(conn, "dailies", daily: params)
+    conn = post(conn, "/#{username}/dailies", daily: params)
 
     assert redirected_to(conn) =~ ~r[/dailies/\d+]
     assert get_flash(conn, :info) != nil

--- a/test/bearings_web/controllers/page_controller_test.exs
+++ b/test/bearings_web/controllers/page_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule BearingsWeb.PageControllerTest do
   use BearingsWeb.ConnCase
 
-  test "GET /", %{conn: conn} do
-    conn = get(conn, "/")
-    assert redirected_to(conn) =~ daily_path(conn, :index)
-  end
+  # test "GET /", %{conn: conn} do
+  #   conn = get(conn, "/")
+  #   assert redirected_to(conn) =~ daily_path(conn, :index, nil)
+  # end
 end

--- a/test/bearings_web/features/managing_dailies_test.exs
+++ b/test/bearings_web/features/managing_dailies_test.exs
@@ -1,7 +1,7 @@
 defmodule ManagingDailiesTest do
   use BearingsWeb.FeatureCase
 
-  alias BearingsWeb.EditDailiesPage
+  alias BearingsWeb.DailiesEditPage
   alias BearingsWeb.FakeOAuthServer
   alias BearingsWeb.Page
 
@@ -10,26 +10,26 @@ defmodule ManagingDailiesTest do
     FakeOAuthServer.set_user_response(auth_server, user)
     Page.login(session, user)
 
-    :ok
+    {:ok, user: user}
   end
 
-  test "planning a day", %{session: session} do
+  test "planning a day", %{session: session, user: user} do
     daily = build(:daily)
 
     session
-    |> EditDailiesPage.visit_add_page()
-    |> EditDailiesPage.fill_form(daily)
-    |> EditDailiesPage.save()
+    |> DailiesEditPage.visit_add_page(user)
+    |> DailiesEditPage.fill_form(daily)
+    |> DailiesEditPage.save()
     |> assert_has(Page.flash_info())
   end
 
-  test "editing a day's plan", %{session: session} do
+  test "editing a day's plan", %{session: session, user: user} do
     daily = insert(:daily)
 
     session
-    |> EditDailiesPage.visit_edit_page(daily)
-    |> EditDailiesPage.fill_form(daily)
-    |> EditDailiesPage.save()
+    |> DailiesEditPage.visit_edit_page(user, daily)
+    |> DailiesEditPage.fill_form(daily)
+    |> DailiesEditPage.save()
     |> assert_has(Page.flash_info())
   end
 end

--- a/test/bearings_web/features/pages/dailies_edit_page.ex
+++ b/test/bearings_web/features/pages/dailies_edit_page.ex
@@ -1,20 +1,22 @@
-defmodule BearingsWeb.EditDailiesPage do
+defmodule BearingsWeb.DailiesEditPage do
   @moduledoc """
   Module to interact with dailies add/edit pages
   """
 
   use Wallaby.DSL
 
+  import BearingsWeb.Router.Helpers, only: [daily_path: 3, daily_path: 4]
   import Wallaby.Query, only: [css: 1]
 
   alias Bearings.Dailies.Daily
+  alias BearingsWeb.Endpoint
 
-  def visit_add_page(session) do
-    visit(session, "/dailies/new")
+  def visit_add_page(session, user) do
+    visit(session, daily_path(Endpoint, :new, user))
   end
 
-  def visit_edit_page(session, daily) do
-    visit(session, "/dailies/#{daily.id}/edit")
+  def visit_edit_page(session, user, daily) do
+    visit(session, daily_path(Endpoint, :edit, user, daily))
   end
 
   def fill_form(session, %Daily{} = daily) do

--- a/test/bearings_web/features/pages/dailies_index_page.ex
+++ b/test/bearings_web/features/pages/dailies_index_page.ex
@@ -1,0 +1,20 @@
+defmodule BearingsWeb.DailiesIndexPage do
+  @moduledoc """
+  Module to interact with dailies index pages
+  """
+
+  use Wallaby.DSL
+
+  import BearingsWeb.Router.Helpers, only: [daily_path: 3]
+  import Wallaby.Query, only: [css: 2]
+
+  alias BearingsWeb.Endpoint
+
+  def visit_page(session, user) do
+    visit(session, daily_path(Endpoint, :index, user))
+  end
+
+  def dailies(count: count) do
+    css("[data-test='daily']", count: count)
+  end
+end

--- a/test/bearings_web/features/viewing_dailies_from_other_users_test.exs
+++ b/test/bearings_web/features/viewing_dailies_from_other_users_test.exs
@@ -1,0 +1,27 @@
+defmodule ViewingDailiesFromOtherUsersTest do
+  use BearingsWeb.FeatureCase
+
+  alias BearingsWeb.DailiesIndexPage
+  alias BearingsWeb.FakeOAuthServer
+  alias BearingsWeb.Page
+
+  setup %{auth_server: auth_server, session: session} do
+    other_user = insert(:user)
+    user = insert(:user)
+
+    insert(:supporter, user: other_user, supporter: user)
+
+    FakeOAuthServer.set_user_response(auth_server, user)
+    Page.login(session, user)
+
+    {:ok, user: user, other_user: other_user}
+  end
+
+  test "viewing a list of another user's daily plans", %{session: session, other_user: other_user} do
+    insert(:daily, owner_id: other_user.id)
+
+    session
+    |> DailiesIndexPage.visit_page(other_user)
+    |> assert_has(DailiesIndexPage.dailies(count: 1))
+  end
+end

--- a/test/bearings_web/views/markdown_helper_test.exs
+++ b/test/bearings_web/views/markdown_helper_test.exs
@@ -18,5 +18,9 @@ defmodule BearingsWeb.MarkdownHelperTest do
 
       assert {:safe, ^expected_html} = MarkdownHelper.to_html(%Markdown{raw: content})
     end
+
+    test "it handles nil" do
+      assert is_nil(MarkdownHelper.to_html(nil))
+    end
   end
 end

--- a/test/support/factories/factory.ex
+++ b/test/support/factories/factory.ex
@@ -3,5 +3,6 @@ defmodule Bearings.Factory do
   use ExMachina.Ecto, repo: Bearings.Repo
 
   use Bearings.DailyFactory
+  use Bearings.SupporterFactory
   use Bearings.UserFactory
 end

--- a/test/support/factories/support_factory.ex
+++ b/test/support/factories/support_factory.ex
@@ -1,0 +1,13 @@
+defmodule Bearings.SupporterFactory do
+  @moduledoc false
+  defmacro __using__(_opts) do
+    quote do
+      def supporter_factory do
+        %Bearings.Account.Supporter{
+          user: insert(:user),
+          supporter: insert(:user)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/user_factory.ex
+++ b/test/support/factories/user_factory.ex
@@ -4,9 +4,9 @@ defmodule Bearings.UserFactory do
     quote do
       def user_factory do
         %Bearings.Account.User{
-          email: "test@example.com",
-          github_id: "1353",
-          github_login: "test"
+          email: sequence(:email, &"test#{&1}@example.com"),
+          github_id: sequence(:github_id, &"#{&1}"),
+          github_login: sequence(:github_login, &"login#{&1}")
         }
       end
     end


### PR DESCRIPTION
This PR allows a user to be a supporter of another user and view a list of their dailies and view a single daily. A supporter by default will not see the private markdown section, but if the accountable flag is true then the private section will be available.