### PR TITLE
Allow users to dynamically add and remove goals from daily plan

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -83,7 +83,7 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
   border-radius: 50% 50% 50% 50%;
   transform: scale(0.90) translate(0px);
 }
-// How To Make Rounded Avatars http://wp.me/p1lTu0-9VQ
+
 .avatar {
   margin: 1em;
   width: 40px;
@@ -91,4 +91,8 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
   border-radius: 50% 50% 50% 50%;
   transition:All 0.2s ease;
   transform: scale(1);
+}
+
+.goals-form > .row {
+  margin-top: 1em;
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,3 +2,6 @@ import '../css/app.scss'
 import '@babel/polyfill'
 import 'phoenix_html'
 import 'bootstrap'
+import DailyForm from './daily-form'
+
+const dailyForm = new DailyForm();

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,4 +4,6 @@ import 'phoenix_html'
 import 'bootstrap'
 import DailyForm from './daily-form'
 
-const dailyForm = new DailyForm();
+if (document.getElementById('add-goal-btn')) {
+  DailyForm.init()
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5,5 +5,6 @@ import 'bootstrap'
 import DailyForm from './daily-form'
 
 if (document.getElementById('add-goal-btn')) {
-  DailyForm.init()
+  const dailyForm = new DailyForm()
+  dailyForm.joinDailyChannel()
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,5 +6,6 @@ import DailyForm from './daily-form'
 
 if (document.getElementById('add-goal-btn')) {
   const dailyForm = new DailyForm()
+
   dailyForm.joinDailyChannel()
 }

--- a/assets/js/daily-form.js
+++ b/assets/js/daily-form.js
@@ -1,0 +1,64 @@
+export default class DailyForm {
+
+  constructor() {
+    const addGoalButton = document.getElementById("add-goal-btn");
+    if (addGoalButton) {
+      addGoalButton.addEventListener('click', (event) => {
+        this.addGoal();
+      }, false);
+    }
+  }
+
+  addGoal() {
+    const goalsDiv = document.querySelector('.goals-form');
+    const goalsCount = goalsDiv.querySelectorAll('.form-control').length;
+    const newInput = this.createGoalForm(goalsCount);
+
+    goalsDiv.appendChild(newInput);
+  }
+
+  createGoalForm(goalsCount) {
+    const row = this.createDiv(`row goal-inputs-${goalsCount}`);
+    const inputCol = this.createDiv('col-10');
+    const input = this.createGoalInput(goalsCount);
+    const removeCol = this.createDiv('col');
+    const removeBtn = this.createRemoveBtn(goalsCount);
+    inputCol.appendChild(input);
+    removeCol.appendChild(removeBtn);
+    row.appendChild(inputCol);
+    row.appendChild(removeCol);
+    return row;
+  }
+
+  createDiv(className) {
+    const div = document.createElement('div');
+    div.setAttribute('class', className);
+    return div;
+  }
+
+  createGoalInput(goalsCount) {
+    const input = document.createElement('input');
+    input.setAttribute('class', 'form-control');
+    input.setAttribute('data-test', `goal-${goalsCount}`);
+    input.setAttribute('id', `daily_goals_${goalsCount}_body`);
+    input.setAttribute('name', `daily[goals][${goalsCount}][body]`);
+    input.setAttribute('type', 'text');
+    return input;
+  }
+
+  createRemoveBtn(index) {
+    const btn = document.createElement('button');
+    btn.setAttribute('class', 'btn btn-danger');
+    btn.setAttribute('type', 'button')
+    btn.innerText ='Remove';
+    btn.addEventListener('click', (e) => {
+      this.removeGoal(index);
+    }, false);
+    return btn;
+  }
+
+  removeGoal(index) {
+    const goalInputs = document.querySelector(`.goal-inputs-${index}`);
+    goalInputs.remove();
+  }
+}

--- a/assets/js/daily-form.js
+++ b/assets/js/daily-form.js
@@ -1,64 +1,63 @@
 export default class DailyForm {
-
-  constructor() {
-    const addGoalButton = document.getElementById("add-goal-btn");
+  static init () {
+    const addGoalButton = document.getElementById('add-goal-btn')
     if (addGoalButton) {
       addGoalButton.addEventListener('click', (event) => {
-        this.addGoal();
-      }, false);
+        this.addGoal()
+      }, false)
     }
   }
 
-  addGoal() {
-    const goalsDiv = document.querySelector('.goals-form');
-    const goalsCount = goalsDiv.querySelectorAll('.form-control').length;
-    const newInput = this.createGoalForm(goalsCount);
+  static addGoal () {
+    const goalsDiv = document.querySelector('.goals-form')
+    const goalsCount = goalsDiv.querySelectorAll('.form-control').length
+    const newInput = this.createGoalForm(goalsCount)
 
-    goalsDiv.appendChild(newInput);
+    goalsDiv.appendChild(newInput)
   }
 
-  createGoalForm(goalsCount) {
-    const row = this.createDiv(`row goal-inputs-${goalsCount}`);
-    const inputCol = this.createDiv('col-10');
-    const input = this.createGoalInput(goalsCount);
-    const removeCol = this.createDiv('col');
-    const removeBtn = this.createRemoveBtn(goalsCount);
-    inputCol.appendChild(input);
-    removeCol.appendChild(removeBtn);
-    row.appendChild(inputCol);
-    row.appendChild(removeCol);
-    return row;
+  static createGoalForm (goalsCount) {
+    const row = this.createDiv(`row goal-inputs-${goalsCount}`)
+    const inputCol = this.createDiv('col-10')
+    const input = this.createGoalInput(goalsCount)
+    const removeCol = this.createDiv('col')
+    const removeBtn = this.createRemoveBtn(goalsCount)
+    inputCol.appendChild(input)
+    removeCol.appendChild(removeBtn)
+    row.appendChild(inputCol)
+    row.appendChild(removeCol)
+    return row
   }
 
-  createDiv(className) {
-    const div = document.createElement('div');
-    div.setAttribute('class', className);
-    return div;
+  static createDiv (className) {
+    const div = document.createElement('div')
+    div.setAttribute('class', className)
+    return div
   }
 
-  createGoalInput(goalsCount) {
-    const input = document.createElement('input');
-    input.setAttribute('class', 'form-control');
-    input.setAttribute('data-test', `goal-${goalsCount}`);
-    input.setAttribute('id', `daily_goals_${goalsCount}_body`);
-    input.setAttribute('name', `daily[goals][${goalsCount}][body]`);
-    input.setAttribute('type', 'text');
-    return input;
+  static createGoalInput (goalsCount) {
+    const input = document.createElement('input')
+    input.setAttribute('class', 'form-control')
+    input.setAttribute('data-test', `goal-${goalsCount}`)
+    input.setAttribute('id', `daily_goals_${goalsCount}_body`)
+    input.setAttribute('name', `daily[goals][${goalsCount}][body]`)
+    input.setAttribute('type', 'text')
+    return input
   }
 
-  createRemoveBtn(index) {
-    const btn = document.createElement('button');
-    btn.setAttribute('class', 'btn btn-danger');
+  static createRemoveBtn (index) {
+    const btn = document.createElement('button')
+    btn.setAttribute('class', 'btn btn-danger')
     btn.setAttribute('type', 'button')
-    btn.innerText ='Remove';
+    btn.innerText = 'Remove'
     btn.addEventListener('click', (e) => {
-      this.removeGoal(index);
-    }, false);
-    return btn;
+      this.removeGoal(index)
+    }, false)
+    return btn
   }
 
-  removeGoal(index) {
-    const goalInputs = document.querySelector(`.goal-inputs-${index}`);
-    goalInputs.remove();
+  static removeGoal (index) {
+    const goalInputs = document.querySelector(`.goal-inputs-${index}`)
+    goalInputs.remove()
   }
 }

--- a/assets/js/daily-form.js
+++ b/assets/js/daily-form.js
@@ -1,13 +1,12 @@
 import { Socket } from 'phoenix'
 
 export default class DailyForm {
-
-  constructor() {
+  constructor () {
     this.channel = this.initChannel()
     this.goalsForm = document.querySelector('.goals-form')
   }
 
-  initChannel() {
+  initChannel () {
     let socket = new Socket('/socket', {})
     socket.connect()
 
@@ -15,7 +14,7 @@ export default class DailyForm {
     return channel
   }
 
-  getDailyId() {
+  getDailyId () {
     // Gets the date from the location, allowing
     // us to get the daily ID to connect to the
     // right channel.
@@ -23,23 +22,23 @@ export default class DailyForm {
     return location.match(/(\d{4})-(\d{1,2})-(\d{1,2})/)[0]
   }
 
-  getUserName() {
+  getUserName () {
     // Gets the username from location
     // The channel requires the username
     // to be passed in as a parameter
     return document.location.href.match(/\/(.*)\/(.*)\/dailies/)[2]
   }
 
-  joinDailyChannel() {
+  joinDailyChannel () {
     this.channel.join()
       .receive('ok', () => {
-       this.initAddGoalButton()
-       this.setChannelEventListeners()
-     })
+        this.initAddGoalButton()
+        this.setChannelEventListeners()
+      })
       .receive('error', resp => { console.log('Failed to join daily channel', resp) })
   }
 
-  initAddGoalButton() {
+  initAddGoalButton () {
     const addGoalButton = document.getElementById('add-goal-btn')
     if (addGoalButton) {
       addGoalButton.addEventListener('click', (event) => {
@@ -48,7 +47,7 @@ export default class DailyForm {
     }
   }
 
-  setChannelEventListeners() {
+  setChannelEventListeners () {
     this.channel.on('new_goal_form', (payload) => {
       console.log('Got new goal with ', payload)
       if (this.goalsForm) {
@@ -57,30 +56,16 @@ export default class DailyForm {
         }
         this.goalsForm.insertAdjacentHTML('beforeend', payload.html)
         this.attachRemoveBtnEventListeners()
-        this.attachSaveBtnEventListeners()
       }
     })
   }
 
-  attachRemoveBtnEventListeners() {
+  attachRemoveBtnEventListeners () {
     const btns = this.goalsForm.querySelectorAll('.remove-btn')
     if (btns && btns.length > 0) {
       btns.forEach((btn) => {
         btn.addEventListener('click', (e) => {
-          this.channel.push(btn.data.eventMessage)
-        }, false)
-      })
-    }
-  }
-
-  attachSaveBtnEventListeners() {
-    const btns = this.goalsForm.querySelectorAll('.save-btn')
-    if (btns && btns.length > 0) {
-      btns.forEach((btn) => {
-        btn.addEventListener('click', (e) => {
-          const index = btn.data.index
-          const input = this.goalsForm.querySelector(`#goal-${index}`)
-          this.channel.push(btn.data.eventMessage, {body: input.value})
+          this.channel.push(btn.id)
         }, false)
       })
     }

--- a/lib/bearings/dailies/dailies.ex
+++ b/lib/bearings/dailies/dailies.ex
@@ -7,7 +7,7 @@ defmodule Bearings.Dailies do
   alias Bearings.Repo
 
   alias Bearings.Account.User
-  alias Bearings.Dailies.Daily
+  alias Bearings.Dailies.{Daily, Goal}
 
   @doc """
   Returns the list of dailies for the user and anyone the user supports.
@@ -43,6 +43,7 @@ defmodule Bearings.Dailies do
     |> preload([d], [:owner])
     |> order_by(:date)
     |> Repo.all()
+    |> Repo.preload([:goals])
   end
 
   @doc """
@@ -54,6 +55,16 @@ defmodule Bearings.Dailies do
     |> where([d], d.date == ^date)
     |> where([_d, o], o.username == ^username)
     |> Repo.one!()
+    |> Repo.preload([:goals])
+  end
+
+  @doc """
+  Gets a single Goal
+  """
+  def get_goal!(id) do
+    Goal
+    |> Repo.get(id)
+    |> Repo.preload([:daily])
   end
 
   @doc """
@@ -106,6 +117,21 @@ defmodule Bearings.Dailies do
   """
   def delete_daily(%Daily{} = daily) do
     Repo.delete(daily)
+  end
+
+  @doc """
+  Deletes a Goal.
+
+  ## Examples
+
+      iex> delete_goal(goal)
+      {:ok, %Goal{}}
+
+      iex> delete_goal(goal)
+      {:error, %Ecto.Changeset{}}
+  """
+  def delete_goal(%Goal{} = goal) do
+    Repo.delete(goal)
   end
 
   @doc """

--- a/lib/bearings/dailies/daily.ex
+++ b/lib/bearings/dailies/daily.ex
@@ -7,12 +7,13 @@ defmodule Bearings.Dailies.Daily do
   import Ecto.Changeset
 
   alias Bearings.Account.User
-  alias Bearings.Dailies.Markdown
+  alias Bearings.Dailies.{Markdown, Goal}
 
   @type t :: %__MODULE__{
           date: Date.t(),
           personal_journal: Markdown.t(),
-          daily_plan: Markdown.t()
+          daily_plan: Markdown.t(),
+          goals: list(Goal.t())
         }
 
   schema "dailies" do
@@ -20,6 +21,7 @@ defmodule Bearings.Dailies.Daily do
     field(:personal_journal, Markdown)
     field(:daily_plan, Markdown)
     belongs_to(:owner, User)
+    has_many(:goals, Goal, on_delete: :nilify_all, on_replace: :nilify)
 
     timestamps()
   end
@@ -32,6 +34,7 @@ defmodule Bearings.Dailies.Daily do
   def changeset(daily, attrs) do
     daily
     |> cast(attrs, [:date, :owner_id, :daily_plan, :personal_journal])
+    |> cast_assoc(:goals)
     |> validate_required([:date, :owner_id, :daily_plan])
     |> unique_constraint(:date, name: :unique_owner_id_date)
   end

--- a/lib/bearings/dailies/daily.ex
+++ b/lib/bearings/dailies/daily.ex
@@ -21,7 +21,7 @@ defmodule Bearings.Dailies.Daily do
     field(:personal_journal, Markdown)
     field(:daily_plan, Markdown)
     belongs_to(:owner, User)
-    has_many(:goals, Goal, on_delete: :nilify_all, on_replace: :nilify)
+    has_many(:goals, Goal, on_delete: :delete_all, on_replace: :delete)
 
     timestamps()
   end
@@ -37,5 +37,19 @@ defmodule Bearings.Dailies.Daily do
     |> cast_assoc(:goals)
     |> validate_required([:date, :owner_id, :daily_plan])
     |> unique_constraint(:date, name: :unique_owner_id_date)
+  end
+
+  @doc """
+  Parses a date string into a DateTime struct
+  """
+  @spec parse_date(String.t()) :: DateTime.t() | nil
+  def parse_date(date_string) do
+    case Timex.parse(date_string, "{YYYY}-{M}-{D}") do
+      {:ok, datetime} ->
+        Timex.to_date(datetime)
+
+      _ ->
+        nil
+    end
   end
 end

--- a/lib/bearings/dailies/goal.ex
+++ b/lib/bearings/dailies/goal.ex
@@ -1,0 +1,39 @@
+defmodule Bearings.Dailies.Goal do
+  @moduledoc """
+  This module contains an Ecto Schema and functions for working
+  with daily goals
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Bearings.Dailies.Daily
+
+  @type t :: %__MODULE__{
+          body: String.t(),
+          completed: boolean,
+          daily: Daily.t()
+        }
+
+  schema "goals" do
+    field(:body, :string)
+    field(:completed, :boolean)
+    belongs_to(:daily, Daily)
+
+    timestamps()
+  end
+
+  def filter_attrs(%{"goals" => goals}) do
+    Enum.reduce(goals, %{}, fn {key, goal_attrs}, acc ->
+      case String.length(goal_attrs["body"]) > 0 do
+        true -> %{acc | key => goal_attrs}
+        false -> acc
+      end
+    end)
+  end
+
+  def changeset(goal, attrs) do
+    goal
+    |> cast(attrs, [:body])
+    |> validate_required([:body])
+  end
+end

--- a/lib/bearings_web/channels/daily_channel.ex
+++ b/lib/bearings_web/channels/daily_channel.ex
@@ -1,0 +1,80 @@
+defmodule BearingsWeb.DailyChannel do
+  use Phoenix.Channel
+
+  alias Bearings.Dailies
+  alias Bearings.Dailies.{Daily, Goal}
+  alias BearingsWeb.DailyView
+
+  ########
+  # JOIN #
+  ########
+
+  def join("dailies:" <> daily_date, %{"username" => user}, socket) do
+    send(self(), {:after_join, Daily.parse_date(daily_date), user})
+
+    {:ok, %{}, socket}
+  end
+
+  #####################
+  # INCOMING MESSAGES #
+  #####################
+
+  def handle_in("add_goal", _params, socket) do
+    socket = update_daily(socket, :add_goal)
+    push(socket, "new_goal_form", %{html: DailyView.render_goal_fields(socket.assigns.daily)})
+    {:noreply, socket}
+  end
+
+  def handle_in("remove_goal", _params, socket) do
+    socket = update_daily(socket, :remove_one_unsaved)
+    push(socket, "new_goal_form", %{html: DailyView.render_goal_fields(socket.assigns.daily)})
+    {:noreply, socket}
+  end
+
+  def handle_in("remove_goal" <> id, _params, socket) do
+    with {:ok, _} <- Dailies.get_goal!(id) |> Dailies.delete_goal() do
+      socket = update_daily(socket, :refetch)
+      push(socket, "new_goal_form", %{html: DailyView.render_goal_fields(socket.assigns.daily)})
+      {:noreply, socket}
+    else
+      _ -> {:reply, {:error, %{message: "Could not delete goal"}}, socket}
+    end
+  end
+
+  ############
+  # INTERNAL #
+  ############
+
+  def handle_info({:after_join, daily_date, username}, socket) do
+    socket = assign(socket, :daily, Dailies.get_daily!(daily_date, username))
+    |> assign(:username, username)
+    {:noreply, socket}
+  end
+
+  ####################
+  # HELPER FUNCTIONS #
+  ####################
+
+  defp update_daily(%{assigns: %{daily: daily}} = socket, :add_goal) do
+    assign(socket, :daily, %Daily{ daily | goals: daily.goals ++ [%Goal{}]})
+  end
+
+  defp update_daily(%{assigns: %{daily: daily}} = socket, :refetch) do
+    {_, unsaved} = unsaved_goals(daily)
+    daily = Dailies.get_daily!(daily.date, socket.assigns.username)
+    assign(socket, :daily, %Daily{ daily | goals: daily.goals ++ unsaved})
+  end
+
+  defp update_daily(%{assigns: %{daily: daily}} = socket, :remove_one_unsaved) do
+    assign(socket, :daily, drop_one_unsaved_goal(daily))
+  end
+
+  defp unsaved_goals(daily) do
+    Enum.split_with(daily.goals, &(&1.id))
+  end
+
+  defp drop_one_unsaved_goal(daily) do
+    {saved, unsaved} = unsaved_goals(daily)
+    %Daily{ daily | goals: saved ++ Enum.drop(unsaved, 1)}
+  end
+end

--- a/lib/bearings_web/channels/user_socket.ex
+++ b/lib/bearings_web/channels/user_socket.ex
@@ -1,6 +1,8 @@
 defmodule BearingsWeb.UserSocket do
   use Phoenix.Socket
 
+  channel("dailies:*", BearingsWeb.DailyChannel)
+
   transport(:websocket, Phoenix.Transports.WebSocket, timeout: 45_000)
 
   def connect(_params, socket) do

--- a/lib/bearings_web/controllers/daily_controller.ex
+++ b/lib/bearings_web/controllers/daily_controller.ex
@@ -59,7 +59,7 @@ defmodule BearingsWeb.DailyController do
   end
 
   def new(conn, _params, _) do
-    changeset = Dailies.change_daily(%Daily{})
+    changeset = Dailies.change_daily(%Daily{goals: [%Bearings.Dailies.Goal{}]})
     render(conn, "new.html", changeset: changeset)
   end
 

--- a/lib/bearings_web/controllers/goal_controller.ex
+++ b/lib/bearings_web/controllers/goal_controller.ex
@@ -1,0 +1,24 @@
+defmodule BearingsWeb.GoalController do
+  use BearingsWeb, :controller
+
+  alias Bearings.Dailies
+
+  plug(BearingsWeb.Auth when action in [:delete])
+
+  def delete(conn, %{"id" => id, "username" => _user}) do
+    goal = Dailies.get_goal!(id)
+
+    if goal.daily.owner_id == conn.assigns.current_user.id do
+      with {:ok, _} <- Dailies.delete_goal(goal) do
+        conn
+        |> put_flash(:info, "Goal successfully deleted")
+        |> redirect(to: daily_path(conn, :edit, conn.assigns.current_user, goal.daily))
+      end
+    else
+      conn
+      |> put_status(:not_found)
+      |> render(BearingsWeb.ErrorView, "404.html")
+      |> halt()
+    end
+  end
+end

--- a/lib/bearings_web/router.ex
+++ b/lib/bearings_web/router.ex
@@ -26,6 +26,7 @@ defmodule BearingsWeb.Router do
     pipe_through(:browser)
 
     resources("/dailies", DailyController, as: :daily)
+    delete("/goals/:id", GoalController, :delete)
   end
 
   scope "/auth", BearingsWeb do

--- a/lib/bearings_web/templates/daily/form.html.eex
+++ b/lib/bearings_web/templates/daily/form.html.eex
@@ -6,6 +6,29 @@
     <%= error_tag f, :date %>
   </div>
 
+  <div class="form-group goals-form">
+    <%= content_tag(:label, "Goals", for: "goals") %>
+    <%= inputs_for f, :goals, fn(g) -> %>
+      <div class="row">
+        <div class="col-10 goal-input">
+          <%= text_input g, :body, class: "form-control", "data-test": "goal-#{g.index}" %>
+          <%= error_tag g, :body %>
+        </div>
+        <div class="col">
+          <%= link("Remove", to: goal_path(@conn, :delete, @conn.assigns.current_user, g.data.id), method: :delete, class: "btn btn-danger") %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="row">
+    <div class="col-sm text-center">
+      <button class="btn btn-primary" id="add-goal-btn" data-test="add_goal" type="button">
+        Add Goal
+      </button>
+    </div>
+  </div>
+
   <div class="form-group">
     <%= label f, :daily_plan, "Daily Plan" %>
     <p class="form-text text-muted">Enter your daily plan here. This will be visible by you and anyone who is a supporter.</p>

--- a/lib/bearings_web/templates/daily/form.html.eex
+++ b/lib/bearings_web/templates/daily/form.html.eex
@@ -7,18 +7,7 @@
   </div>
 
   <div class="form-group goals-form">
-    <%= content_tag(:label, "Goals", for: "goals") %>
-    <%= inputs_for f, :goals, fn(g) -> %>
-      <div class="row">
-        <div class="col-10 goal-input">
-          <%= text_input g, :body, class: "form-control", "data-test": "goal-#{g.index}" %>
-          <%= error_tag g, :body %>
-        </div>
-        <div class="col">
-          <%= link("Remove", to: goal_path(@conn, :delete, @conn.assigns.current_user, g.data.id), method: :delete, class: "btn btn-danger") %>
-        </div>
-      </div>
-    <% end %>
+    <%= render "goal_fields.html", Map.put(assigns, :daily_form, f) %>
   </div>
 
   <div class="row">

--- a/lib/bearings_web/templates/daily/goal_fields.html.eex
+++ b/lib/bearings_web/templates/daily/goal_fields.html.eex
@@ -6,11 +6,7 @@
       <%= error_tag g, :body %>
     </div>
     <div class="col">
-      <%= if g.data.id do %>
-        <%= content_tag(:button, "Remove", class: "btn btn-danger remove-btn", "data-event-message": "remove_goal_#{g.data.id}", type: "button") %>
-      <% else %>
-        <%= content_tag(:button, "Save", class: "btn btn-danger save-btn", "data-event-message": "save_goal_#{g.index}", "data-index": "#{g.index}") %>
-      <% end %>
+      <%= content_tag(:button, "Remove", class: "btn btn-danger remove-btn", id: "remove_goal#{g.data.id}", type: "button") %>
     </div>
   </div>
 <% end %>

--- a/lib/bearings_web/templates/daily/goal_fields.html.eex
+++ b/lib/bearings_web/templates/daily/goal_fields.html.eex
@@ -1,0 +1,16 @@
+<%= content_tag(:label, "Goals", for: "goals") %>
+<%= inputs_for @daily_form, :goals, fn g -> %>
+  <div class="row">
+    <div class="col-10 goal-input">
+      <%= text_input g, :body, class: "form-control", id: "goal-#{g.index}" %>
+      <%= error_tag g, :body %>
+    </div>
+    <div class="col">
+      <%= if g.data.id do %>
+        <%= content_tag(:button, "Remove", class: "btn btn-danger remove-btn", "data-event-message": "remove_goal_#{g.data.id}", type: "button") %>
+      <% else %>
+        <%= content_tag(:button, "Save", class: "btn btn-danger save-btn", "data-event-message": "save_goal_#{g.index}", "data-index": "#{g.index}") %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/lib/bearings_web/views/daily_view.ex
+++ b/lib/bearings_web/views/daily_view.ex
@@ -3,6 +3,7 @@ defmodule BearingsWeb.DailyView do
 
   alias Timex.Interval
   alias Bearings.Dailies.Daily
+  alias Phoenix.HTML.FormData
 
   def calendar(dailies) do
     case dailies_range(dailies) do
@@ -17,6 +18,15 @@ defmodule BearingsWeb.DailyView do
         )
         |> Enum.map(fn day -> add_dailies_for_day(day, dailies) end)
     end
+  end
+
+  def render_goal_fields(%Daily{} = daily) do
+    form =
+      daily
+      |> Daily.changeset(%{})
+      |> FormData.to_form([])
+
+    render_to_string(__MODULE__, "goal_fields.html", daily_form: form)
   end
 
   defp add_dailies_for_day(day, dailies) do
@@ -36,10 +46,5 @@ defmodule BearingsWeb.DailyView do
         {Enum.min_by([start_date, daily.date], &Date.to_erl/1),
          Enum.max_by([end_date, daily.date], &Date.to_erl/1)}
     end)
-
-  def render_goal_fields(%Daily{} = daily) do
-    form = Daily.changeset(daily, %{}) |> Phoenix.HTML.FormData.to_form([])
-
-    render_to_string(__MODULE__, "goal_fields.html", daily_form: form)
   end
 end

--- a/lib/bearings_web/views/daily_view.ex
+++ b/lib/bearings_web/views/daily_view.ex
@@ -2,6 +2,7 @@ defmodule BearingsWeb.DailyView do
   use BearingsWeb, :view
 
   alias Timex.Interval
+  alias Bearings.Dailies.Daily
 
   def calendar(dailies) do
     case dailies_range(dailies) do
@@ -35,5 +36,10 @@ defmodule BearingsWeb.DailyView do
         {Enum.min_by([start_date, daily.date], &Date.to_erl/1),
          Enum.max_by([end_date, daily.date], &Date.to_erl/1)}
     end)
+
+  def render_goal_fields(%Daily{} = daily) do
+    form = Daily.changeset(daily, %{}) |> Phoenix.HTML.FormData.to_form([])
+
+    render_to_string(__MODULE__, "goal_fields.html", daily_form: form)
   end
 end

--- a/priv/repo/migrations/20180527162533_add_goals.exs
+++ b/priv/repo/migrations/20180527162533_add_goals.exs
@@ -1,0 +1,13 @@
+defmodule Bearings.Repo.Migrations.CreateGoals do
+  use Ecto.Migration
+
+  def change do
+    create table(:goals) do
+      add :body, :string
+      add :completed, :boolean, default: false
+      add :daily_id, references(:dailies)
+
+      timestamps()
+    end
+  end
+end

--- a/test/bearings/dailies/dailies_test.exs
+++ b/test/bearings/dailies/dailies_test.exs
@@ -61,6 +61,11 @@ defmodule Bearings.DailiesTest do
     assert %Markdown{raw: "some daily_plan"} = daily.daily_plan
   end
 
+  test "create_daily/1 with invalid goal data returns error changeset" do
+    assert {:error, %Ecto.Changeset{}} =
+             Dailies.create_daily(Map.put(@valid_attrs, :goals, [%{body: ""}]))
+  end
+
   test "create_daily/1 with invalid data returns error changeset" do
     assert {:error, %Ecto.Changeset{}} = Dailies.create_daily(@invalid_attrs)
   end

--- a/test/bearings_web/channels/daily_channel_test.exs
+++ b/test/bearings_web/channels/daily_channel_test.exs
@@ -1,11 +1,14 @@
 defmodule BearingsWeb.DailyChannelTest do
   use BearingsWeb.ChannelCase
 
+  alias Bearings.Dailies.{Daily, Goal}
+  alias BearingsWeb.{UserSocket, DailyView}
+
   setup do
     user = insert(:user)
     daily = insert(:daily, owner_id: user.id)
 
-    {:ok, socket} = connect(BearingsWeb.UserSocket, %{})
+    {:ok, socket} = connect(UserSocket, %{})
 
     {:ok, _, socket} =
       subscribe_and_join(socket, "dailies:#{daily.date}", %{"username" => user.username})
@@ -14,11 +17,13 @@ defmodule BearingsWeb.DailyChannelTest do
   end
 
   describe "handle_in/3" do
-    test "add_goal", %{socket: socket} do
+    test "add_goal", %{socket: socket, daily: daily} do
       push(socket, "add_goal", %{})
-      expected_response = BearingsWeb.DailyView.render_goal_fields()
+      new_goals = daily.goals ++ [%Goal{}]
 
-      assert_push("new_goal", %{html: ^expected_response})
+      expected_response = DailyView.render_goal_fields(%Daily{daily | goals: new_goals})
+
+      assert_push("new_goal_form", %{html: ^expected_response})
     end
   end
 end

--- a/test/bearings_web/channels/daily_channel_test.exs
+++ b/test/bearings_web/channels/daily_channel_test.exs
@@ -1,0 +1,24 @@
+defmodule BearingsWeb.DailyChannelTest do
+  use BearingsWeb.ChannelCase
+
+  setup do
+    user = insert(:user)
+    daily = insert(:daily, owner_id: user.id)
+
+    {:ok, socket} = connect(BearingsWeb.UserSocket, %{})
+
+    {:ok, _, socket} =
+      subscribe_and_join(socket, "dailies:#{daily.date}", %{"username" => user.username})
+
+    {:ok, socket: socket, user: user, daily: daily}
+  end
+
+  describe "handle_in/3" do
+    test "add_goal", %{socket: socket} do
+      push(socket, "add_goal", %{})
+      expected_response = BearingsWeb.DailyView.render_goal_fields()
+
+      assert_push("new_goal", %{html: ^expected_response})
+    end
+  end
+end

--- a/test/bearings_web/controllers/goals_controller_test.exs
+++ b/test/bearings_web/controllers/goals_controller_test.exs
@@ -1,0 +1,33 @@
+defmodule BearingsWeb.GoalsControllerTest do
+  use BearingsWeb.ConnCase
+
+  import BearingsWeb.Router.Helpers, only: [goal_path: 4]
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    conn = assign(conn, :current_user, user)
+    daily = insert(:daily, owner_id: user.id)
+    other = insert(:daily)
+
+    {:ok, conn: conn, daily: daily, other: other, user: user}
+  end
+
+  describe "delete/2" do
+    test "deletes the goal when user is the owner", %{daily: daily, conn: conn, user: user} do
+      conn = delete(conn, goal_path(conn, :delete, user, hd(daily.goals)))
+      expected_date = String.replace("#{daily.date}", ~r(-0), "-")
+      assert redirected_to(conn) =~ "/dailies/#{expected_date}"
+      assert get_flash(conn, :info)
+    end
+
+    test "renders an error unless user owns the associated daily", %{
+      other: other,
+      conn: conn,
+      user: user
+    } do
+      conn = delete(conn, goal_path(conn, :delete, user, hd(other.goals)))
+
+      assert html_response(conn, 404)
+    end
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -22,6 +22,7 @@ defmodule BearingsWeb.ChannelCase do
     quote do
       # Import conveniences for testing with channels
       use Phoenix.ChannelTest
+      import Bearings.Factory
 
       # The default endpoint for testing
       @endpoint BearingsWeb.Endpoint

--- a/test/support/factories/daily_factory.ex
+++ b/test/support/factories/daily_factory.ex
@@ -6,6 +6,7 @@ defmodule Bearings.DailyFactory do
         %Bearings.Dailies.Daily{
           date: sequence(:date, fn seq -> Timex.shift(Date.utc_today(), days: -seq) end),
           owner_id: insert(:user).id,
+          goals: insert_list(3, :goal),
           personal_journal: %Bearings.Dailies.Markdown{raw: "## Private"},
           daily_plan: %Bearings.Dailies.Markdown{raw: "## Public"}
         }

--- a/test/support/factories/factory.ex
+++ b/test/support/factories/factory.ex
@@ -5,4 +5,5 @@ defmodule Bearings.Factory do
   use Bearings.DailyFactory
   use Bearings.SupporterFactory
   use Bearings.UserFactory
+  use Bearings.GoalFactory
 end

--- a/test/support/factories/factory.ex
+++ b/test/support/factories/factory.ex
@@ -3,7 +3,7 @@ defmodule Bearings.Factory do
   use ExMachina.Ecto, repo: Bearings.Repo
 
   use Bearings.DailyFactory
+  use Bearings.GoalFactory
   use Bearings.SupporterFactory
   use Bearings.UserFactory
-  use Bearings.GoalFactory
 end

--- a/test/support/factories/goal_factory.ex
+++ b/test/support/factories/goal_factory.ex
@@ -1,0 +1,10 @@
+defmodule Bearings.GoalFactory do
+  @moduledoc false
+  defmacro __using__(_opts) do
+    quote do
+      def goal_factory do
+        %Bearings.Dailies.Goal{body: "Goal", completed: false}
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #3

This PR allows user to add and remove goals when creating or editing their daily plans. 

For now, `Goal`s are being associated only with `Daily`s. It might be useful to associate `Goal` to each `User` since it is easy to imagine a scenario where a user has a number of goals that they pursue over multiple days. In addition to the text input field this PR introduces for goals, it might make sense to have a dropdown select box that is prepopulated with goals that have been defined by the user before.

The JavaScript client-side code introduced here uses plain JS as I didn't feel the need for a framework just yet. 