### PR TITLE
Show support dailies on own list

### DIFF
--- a/lib/bearings/account/account.ex
+++ b/lib/bearings/account/account.ex
@@ -147,6 +147,7 @@ defmodule Bearings.Account do
     Supporter
     |> join(:inner, [s], u in assoc(s, :user))
     |> where([s, u], s.supporter_id == ^supporter_id and u.username == ^owner_username)
+    |> preload([s], [:user])
     |> Repo.one()
   end
 

--- a/lib/bearings/account/user.ex
+++ b/lib/bearings/account/user.ex
@@ -4,7 +4,10 @@ defmodule Bearings.Account.User do
   """
 
   use Ecto.Schema
+
   import Ecto.Changeset
+
+  alias Bearings.Account.Supporter
 
   schema "users" do
     field(:avatar, :string)
@@ -12,6 +15,11 @@ defmodule Bearings.Account.User do
     field(:github_id, :string)
     field(:username, :string)
     field(:name, :string)
+
+    # relationships where this user is the supporter
+    has_many(:supports, Supporter, foreign_key: :supporter_id)
+    # users that this user supports
+    has_many(:supports_users, through: [:supports, :user])
 
     timestamps()
   end

--- a/lib/bearings/dailies/dailies.ex
+++ b/lib/bearings/dailies/dailies.ex
@@ -18,7 +18,7 @@ defmodule Bearings.Dailies do
   [%Daily{}, ...]
 
   """
-  def list_dailies(username, options \\ []) do
+  def list_dailies(%User{id: user_id}, options \\ []) do
     include_supports = Keyword.get(options, :include_supports, false)
 
     user_ids =
@@ -26,7 +26,7 @@ defmodule Bearings.Dailies do
         true ->
           user =
             User
-            |> where([u], u.username == ^username)
+            |> where([u], u.id == ^user_id)
             |> preload(:supports_users)
             |> Repo.one()
 
@@ -34,12 +34,7 @@ defmodule Bearings.Dailies do
           |> Enum.map(& &1.id)
 
         false ->
-          user =
-            User
-            |> where([u], u.username == ^username)
-            |> Repo.one()
-
-          [user.id]
+          [user_id]
       end
 
     Daily

--- a/lib/bearings_web/controllers/daily_controller.ex
+++ b/lib/bearings_web/controllers/daily_controller.ex
@@ -44,7 +44,7 @@ defmodule BearingsWeb.DailyController do
     render(conn, "edit.html", changeset: changeset, daily: daily)
   end
 
-  def index(conn, %{"username" => username}, %{supporter: %Supporter{include_private: false}}) do
+  def index(conn, %{"username" => username}, %{supporter: %Supporter{}}) do
     dailies =
       username
       |> Dailies.list_dailies()
@@ -56,8 +56,9 @@ defmodule BearingsWeb.DailyController do
   def index(conn, %{"username" => username}, assigns) do
     dailies =
       username
-      |> Dailies.list_dailies()
+      |> Dailies.list_dailies(include_supports: true)
       |> Enum.map(fn daily -> maybe_strip_private(daily, assigns) end)
+      |> Enum.map(&Daily.strip_private_markdown/1)
 
     render(conn, "index.html", dailies: dailies)
   end

--- a/lib/bearings_web/controllers/page_controller.ex
+++ b/lib/bearings_web/controllers/page_controller.ex
@@ -9,7 +9,7 @@ defmodule BearingsWeb.PageController do
     render(conn, "index.html")
   end
 
-  def index(conn, _params, user) do
-    redirect(conn, to: daily_path(conn, :index, user))
+  def index(conn, _params, _) do
+    redirect(conn, to: dailies_path(conn, :index))
   end
 end

--- a/lib/bearings_web/router.ex
+++ b/lib/bearings_web/router.ex
@@ -17,7 +17,7 @@ defmodule BearingsWeb.Router do
   scope "/", BearingsWeb do
     pipe_through(:browser)
 
-    # resources("/dailies", DailyController)
+    resources("/dailies", DailyController, as: :dailies, only: [:index])
 
     get("/", PageController, :index)
   end

--- a/lib/bearings_web/templates/daily/index.html.eex
+++ b/lib/bearings_web/templates/daily/index.html.eex
@@ -1,12 +1,5 @@
 <div class="container daily-list">
   <h4 class="text-primary">Daily Plans</h4>
-  <h5>
-    <%= if @conn.assigns.current_user.username == @conn.params["username"] do %>
-      You and your supports
-    <% else %>
-      <%= @conn.assigns.supporter.user.name || @conn.assigns.supporter.user.username %>
-    <% end %>
-  </h5>
 
   <%= for week <- calendar(@dailies) |> Enum.chunk_every(7, 7) do %>
     <div class="row">
@@ -17,15 +10,15 @@
           </div>
           <%= if Enum.count(dailies) > 0 do %>
             <%= for daily <- dailies do %>
-              <%= link to: daily_path(@conn, :show, daily.owner.username, daily, return_page: daily_path(@conn, :index, @conn.params["username"])), "data-test": "daily" do %>
+              <%= link to: daily_path(@conn, :show, daily.owner.username, daily), "data-test": "daily" do %>
                 <%= img_tag "#{daily.owner.avatar}&size=120", class: "avatar" %>
               <% end %>
             <% end %>
           <% end %>
         </div>
       <% end %>
-      </div>
-    <% end %>
+    </div>
+  <% end %>
 
   <div class="row">
     <div class="col-sm-11 text-right">

--- a/lib/bearings_web/templates/daily/index.html.eex
+++ b/lib/bearings_web/templates/daily/index.html.eex
@@ -1,16 +1,25 @@
 <div class="container daily-list">
   <h4 class="text-primary">Daily Plans</h4>
+  <h5>
+    <%= if @conn.assigns.current_user.username == @conn.params["username"] do %>
+      You and your supports
+    <% else %>
+      <%= @conn.assigns.supporter.user.name || @conn.assigns.supporter.user.username %>
+    <% end %>
+  </h5>
 
   <%= for week <- calendar(@dailies) |> Enum.chunk_every(7, 7) do %>
     <div class="row">
-      <%= for {day, daily} <- week do %>
+      <%= for {day, dailies} <- week do %>
         <div class="col-sm daily-card">
           <div class="bg-secondary text-light">
             <%= Timex.format!(day, "{M}/{D}") %>
           </div>
-          <%= if daily do %>
-            <%= link to: daily_path(@conn, :show, @conn.params["username"], daily), "data-test": "daily" do %>
-              <%= img_tag "#{daily.owner.avatar}&size=120", class: "avatar" %>
+          <%= if Enum.count(dailies) > 0 do %>
+            <%= for daily <- dailies do %>
+              <%= link to: daily_path(@conn, :show, daily.owner.username, daily, return_page: daily_path(@conn, :index, @conn.params["username"])), "data-test": "daily" do %>
+                <%= img_tag "#{daily.owner.avatar}&size=120", class: "avatar" %>
+              <% end %>
             <% end %>
           <% end %>
         </div>

--- a/lib/bearings_web/templates/daily/show.html.eex
+++ b/lib/bearings_web/templates/daily/show.html.eex
@@ -18,7 +18,7 @@
 
   <div class="row daily-footer">
     <div class="col-sm text-right">
-      <%= link "Back to List", to: daily_path(@conn, :index, @conn.params["username"]), class: "btn btn-secondary-outline" %>
+      <%= link "Back to List", to: @conn.params["return_page"] || daily_path(@conn, :index, @conn.params["username"]), class: "btn btn-secondary-outline" %>
       <%= unless Map.has_key?(@conn.assigns, :supporter) do %>
         <%= link "Edit", to: daily_path(@conn, :edit, @conn.params["username"], @daily), class: "btn btn-secondary" %>
         <%= link "Delete", method: :delete, to: daily_path(@conn, :delete, @conn.params["username"], @daily), class: "btn btn-danger" %>

--- a/lib/bearings_web/templates/daily/show.html.eex
+++ b/lib/bearings_web/templates/daily/show.html.eex
@@ -18,7 +18,7 @@
 
   <div class="row daily-footer">
     <div class="col-sm text-right">
-      <%= link "Back to List", to: @conn.params["return_page"] || daily_path(@conn, :index, @conn.params["username"]), class: "btn btn-secondary-outline" %>
+      <%= link "Back to List", to: dailies_path(@conn, :index), class: "btn btn-secondary-outline" %>
       <%= unless Map.has_key?(@conn.assigns, :supporter) do %>
         <%= link "Edit", to: daily_path(@conn, :edit, @conn.params["username"], @daily), class: "btn btn-secondary" %>
         <%= link "Delete", method: :delete, to: daily_path(@conn, :delete, @conn.params["username"], @daily), class: "btn btn-danger" %>

--- a/lib/bearings_web/templates/layout/app.html.eex
+++ b/lib/bearings_web/templates/layout/app.html.eex
@@ -25,7 +25,7 @@
             <ul class="navbar-nav right">
               <ul class="navbar-nav mr-auto">
                 <li class="nav-item active">
-                  <%= link "Dailies", to: daily_path(@conn, :index, @conn.assigns.current_user), class: "nav-link" %>
+                  <%= link "Dailies", to: dailies_path(@conn, :index), class: "nav-link" %>
                 </li>
               </ul>
               <li class="nav-item dropdown">

--- a/lib/bearings_web/views/daily_view.ex
+++ b/lib/bearings_web/views/daily_view.ex
@@ -14,12 +14,12 @@ defmodule BearingsWeb.DailyView do
           until: end_date |> Timex.end_of_week(:sun),
           right_open: false
         )
-        |> Enum.map(fn day -> add_daily_for_day(day, dailies) end)
+        |> Enum.map(fn day -> add_dailies_for_day(day, dailies) end)
     end
   end
 
-  defp add_daily_for_day(day, dailies) do
-    {day, Enum.find(dailies, fn daily -> Date.to_erl(daily.date) == Date.to_erl(day) end)}
+  defp add_dailies_for_day(day, dailies) do
+    {day, Enum.filter(dailies, fn(daily) -> Date.to_erl(daily.date) == Date.to_erl(day) end)}
   end
 
   defp dailies_range(nil), do: nil

--- a/lib/bearings_web/views/daily_view.ex
+++ b/lib/bearings_web/views/daily_view.ex
@@ -19,7 +19,7 @@ defmodule BearingsWeb.DailyView do
   end
 
   defp add_dailies_for_day(day, dailies) do
-    {day, Enum.filter(dailies, fn(daily) -> Date.to_erl(daily.date) == Date.to_erl(day) end)}
+    {day, Enum.filter(dailies, fn daily -> Date.to_erl(daily.date) == Date.to_erl(day) end)}
   end
 
   defp dailies_range(nil), do: nil

--- a/test/bearings/dailies/dailies_test.exs
+++ b/test/bearings/dailies/dailies_test.exs
@@ -3,76 +3,96 @@ defmodule Bearings.DailiesTest do
 
   alias Bearings.Dailies
   alias Bearings.Dailies.Markdown
+  alias Bearings.Dailies.Daily
 
-  describe "dailies" do
-    alias Bearings.Dailies.Daily
+  @valid_attrs %{
+    date: ~D[2010-04-17],
+    personal_journal: "some personal_journal",
+    daily_plan: "some daily_plan"
+  }
+  @update_attrs %{
+    date: ~D[2011-05-18],
+    personal_journal: "some updated personal_journal",
+    daily_plan: "some updated daily_plan"
+  }
+  @invalid_attrs %{date: nil, personal_journal: nil, daily_plan: nil}
 
-    @valid_attrs %{
-      date: ~D[2010-04-17],
-      personal_journal: "some personal_journal",
-      daily_plan: "some daily_plan"
-    }
-    @update_attrs %{
-      date: ~D[2011-05-18],
-      personal_journal: "some updated personal_journal",
-      daily_plan: "some updated daily_plan"
-    }
-    @invalid_attrs %{date: nil, personal_journal: nil, daily_plan: nil}
-
-    test "list_dailies/0 returns all dailies" do
+  describe "list_dailies/2" do
+    setup do
       user = insert(:user)
+      other_user = insert(:user)
+      insert(:supporter, user: other_user, supporter: user)
+
       daily_id = insert(:daily, owner_id: user.id).id
-      assert %Daily{id: ^daily_id} = hd(Dailies.list_dailies(user.username))
+      other_id = insert(:daily, owner_id: other_user.id).id
+
+      {:ok, user: user, daily_id: daily_id, other_id: other_id}
     end
 
-    test "get_daily!/2 returns the daily with given date and username" do
-      user = insert(:user)
-      daily = insert(:daily, owner_id: user.id)
-      assert Dailies.get_daily!(daily.date, user.username) == daily
+    test "list_dailies/2 returns all user's dailies", %{user: user, daily_id: daily_id} do
+      assert 1 == length(Dailies.list_dailies(user))
+      assert %Daily{id: ^daily_id} = hd(Dailies.list_dailies(user))
     end
 
-    test "create_daily/1 with valid data creates a daily" do
-      user = insert(:user)
-      attrs = Map.put(@valid_attrs, :owner_id, user.id)
-      assert {:ok, %Daily{} = daily} = Dailies.create_daily(attrs)
-      assert daily.date == ~D[2010-04-17]
-      assert %Markdown{raw: "some personal_journal"} = daily.personal_journal
-      assert %Markdown{raw: "some daily_plan"} = daily.daily_plan
-    end
+    test "list_dailies/2 returns all user's dailies and the user's supports' dailies when include_supports: true",
+         %{user: user, daily_id: daily_id, other_id: other_id} do
+      actual_ids =
+        user
+        |> Dailies.list_dailies(include_supports: true)
+        |> Enum.map(& &1.id)
 
-    test "create_daily/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Dailies.create_daily(@invalid_attrs)
+      assert 2 == length(actual_ids)
+      assert actual_ids -- [daily_id, other_id] == []
     end
+  end
 
-    test "update_daily/2 with valid data updates the daily" do
-      daily = insert(:daily)
-      assert {:ok, daily} = Dailies.update_daily(daily, @update_attrs)
-      assert %Daily{} = daily
-      assert daily.date == ~D[2011-05-18]
-      assert %Markdown{raw: "some updated personal_journal"} = daily.personal_journal
-      assert %Markdown{raw: "some updated daily_plan"} = daily.daily_plan
+  test "get_daily!/2 returns the daily with given date and username" do
+    user = insert(:user)
+    daily = insert(:daily, owner_id: user.id)
+    assert Dailies.get_daily!(daily.date, user.username) == daily
+  end
+
+  test "create_daily/1 with valid data creates a daily" do
+    user = insert(:user)
+    attrs = Map.put(@valid_attrs, :owner_id, user.id)
+    assert {:ok, %Daily{} = daily} = Dailies.create_daily(attrs)
+    assert daily.date == ~D[2010-04-17]
+    assert %Markdown{raw: "some personal_journal"} = daily.personal_journal
+    assert %Markdown{raw: "some daily_plan"} = daily.daily_plan
+  end
+
+  test "create_daily/1 with invalid data returns error changeset" do
+    assert {:error, %Ecto.Changeset{}} = Dailies.create_daily(@invalid_attrs)
+  end
+
+  test "update_daily/2 with valid data updates the daily" do
+    daily = insert(:daily)
+    assert {:ok, daily} = Dailies.update_daily(daily, @update_attrs)
+    assert %Daily{} = daily
+    assert daily.date == ~D[2011-05-18]
+    assert %Markdown{raw: "some updated personal_journal"} = daily.personal_journal
+    assert %Markdown{raw: "some updated daily_plan"} = daily.daily_plan
+  end
+
+  test "update_daily/2 with invalid data returns error changeset" do
+    user = insert(:user)
+    daily = insert(:daily, owner_id: user.id)
+    assert {:error, %Ecto.Changeset{}} = Dailies.update_daily(daily, @invalid_attrs)
+    assert daily == Dailies.get_daily!(daily.date, user.username)
+  end
+
+  test "delete_daily/1 deletes the daily" do
+    user = insert(:user)
+    daily = insert(:daily, owner_id: user.id)
+    assert {:ok, %Daily{}} = Dailies.delete_daily(daily)
+
+    assert_raise Ecto.NoResultsError, fn ->
+      Dailies.get_daily!(daily.date, user.username)
     end
+  end
 
-    test "update_daily/2 with invalid data returns error changeset" do
-      user = insert(:user)
-      daily = insert(:daily, owner_id: user.id)
-      assert {:error, %Ecto.Changeset{}} = Dailies.update_daily(daily, @invalid_attrs)
-      assert daily == Dailies.get_daily!(daily.date, user.username)
-    end
-
-    test "delete_daily/1 deletes the daily" do
-      user = insert(:user)
-      daily = insert(:daily, owner_id: user.id)
-      assert {:ok, %Daily{}} = Dailies.delete_daily(daily)
-
-      assert_raise Ecto.NoResultsError, fn ->
-        Dailies.get_daily!(daily.date, user.username)
-      end
-    end
-
-    test "change_daily/1 returns a daily changeset" do
-      daily = insert(:daily)
-      assert %Ecto.Changeset{} = Dailies.change_daily(daily)
-    end
+  test "change_daily/1 returns a daily changeset" do
+    daily = insert(:daily)
+    assert %Ecto.Changeset{} = Dailies.change_daily(daily)
   end
 end

--- a/test/bearings_web/controllers/page_controller_test.exs
+++ b/test/bearings_web/controllers/page_controller_test.exs
@@ -3,6 +3,6 @@ defmodule BearingsWeb.PageControllerTest do
 
   # test "GET /", %{conn: conn} do
   #   conn = get(conn, "/")
-  #   assert redirected_to(conn) =~ daily_path(conn, :index, nil)
+  #   assert redirected_to(conn) =~ dailies_path(conn, :index)
   # end
 end

--- a/test/bearings_web/features/pages/dailies_index_page.ex
+++ b/test/bearings_web/features/pages/dailies_index_page.ex
@@ -5,13 +5,13 @@ defmodule BearingsWeb.DailiesIndexPage do
 
   use Wallaby.DSL
 
-  import BearingsWeb.Router.Helpers, only: [daily_path: 3]
+  import BearingsWeb.Router.Helpers, only: [dailies_path: 2]
   import Wallaby.Query, only: [css: 2]
 
   alias BearingsWeb.Endpoint
 
-  def visit_page(session, user) do
-    visit(session, daily_path(Endpoint, :index, user))
+  def visit_page(session) do
+    visit(session, dailies_path(Endpoint, :index))
   end
 
   def dailies(count: count) do

--- a/test/bearings_web/features/viewing_dailies_from_other_users_test.exs
+++ b/test/bearings_web/features/viewing_dailies_from_other_users_test.exs
@@ -21,7 +21,7 @@ defmodule ViewingDailiesFromOtherUsersTest do
     insert(:daily, owner_id: other_user.id)
 
     session
-    |> DailiesIndexPage.visit_page(other_user)
+    |> DailiesIndexPage.visit_page()
     |> assert_has(DailiesIndexPage.dailies(count: 1))
   end
 end


### PR DESCRIPTION
This PR shows daily plans for all of your supports in the daily list along with your own. In order for this to really make sense, the dailies list page is now top level and not in the username scope. The username scope is still used for the CRUD operations on a daily, so that url paths make sense and can be resolved when sent to other users.