### PR TITLE
Style text and forms

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -7,6 +7,7 @@
 @import "./daily-card";
 @import "./daily-form";
 @import "./utilities";
+@import "./forms";
 
 /* h3 { */
 /*   font-weight: 700; */

--- a/assets/css/forms.scss
+++ b/assets/css/forms.scss
@@ -1,0 +1,7 @@
+.form-control {
+  border-radius: 0;
+}
+
+.textarea-medium {
+  min-height: 150px;
+}

--- a/assets/css/utilities.scss
+++ b/assets/css/utilities.scss
@@ -143,3 +143,7 @@
     }
   }
 }
+
+.small-text {
+  font-size: .8rem;
+}

--- a/lib/bearings_web/templates/daily/form.html.eex
+++ b/lib/bearings_web/templates/daily/form.html.eex
@@ -58,21 +58,26 @@
 </div>
 
 <div class="form-group row">
-  <%= label f, :daily_plan, "Plan", class: "col-sm-3 text-sm-right" %>
+  <div class="col-sm-3 text-sm-right u-push-md-left">
+    <%= label f, :daily_plan, "Plan" %>
+    <p class="form-text text-muted small-text">Enter your daily plan here. This will be visible by you and anyone who is a supporter.</p>
+  </div>
   <div class="col-sm-8">
-    <p class="form-text text-muted">Enter your daily plan here. This will be visible by you and anyone who is a supporter.</p>
-    <%= textarea(f, :daily_plan, class: "markdown form-control", "data-test": "daily_plan") %>
-    <p class="form-text text-muted">This field accepts Markdown. For a quick reference, see <a href="http://commonmark.org/help/" class="text-muted">http://commonmark.org/help/</a></p>
+    <%= textarea(f, :daily_plan, class: "markdown form-control textarea-medium", "data-test": "daily_plan") %>
+    <p class="form-text text-muted small-text">This field accepts Markdown. For a quick reference, see <a href="http://commonmark.org/help/" class="text-muted">http://commonmark.org/help/</a></p>
     <%= error_tag f, :daily_plan %>
   </div>
 </div>
 
 <div class="form-group row">
-  <%= label f, :personal_journal, "Personal Journal", class: "col-sm-3 text-sm-right" %>
+  <div class="col-sm-3 text-sm-right u-push-md-left">
+    <%= label f, :personal_journal, "Personal Journal" %>
+    <div class="text-muted">Optional</div>
+    <p class="form-text text-muted small-text">This is a journal area for you. It will be only be visible to you by default.</p>
+  </div>
   <div class="col-sm-8">
-    <p class="form-text text-muted"><i>Optional</i> <br/> This is a journal area for you. It will be only be visible to you by default.</p>
-    <%= textarea(f, :personal_journal, class: "markdown form-control", "data-test": "personal_journal") %>
-    <p class="form-text text-muted">This field accepts Markdown. For a quick reference, see <a href="http://commonmark.org/help/" class="text-muted">http://commonmark.org/help/</a></p>
+    <%= textarea(f, :personal_journal, class: "markdown form-control textarea-medium", "data-test": "personal_journal") %>
+    <p class="form-text text-muted small-text">This field accepts Markdown. For a quick reference, see <a href="http://commonmark.org/help/" class="text-muted">http://commonmark.org/help/</a></p>
     <%= error_tag f, :personal_journal %>
   </div>
 </div>

--- a/lib/bearings_web/templates/daily/show.html.eex
+++ b/lib/bearings_web/templates/daily/show.html.eex
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="px-0 mt-0 mt-lg-4 mx-auto col-12 col-lg-9 daily">
+  <div class="px-0 mt-0 mt-lg-4 mx-auto col-12 col-lg-9 daily-form">
     <%= render "daily.html", assigns %>
   </div>
 </div>

--- a/lib/bearings_web/templates/template/edit.html.eex
+++ b/lib/bearings_web/templates/template/edit.html.eex
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="template-form px-0 mx-auto mt-0 mt-md-4 col-lg-6">
+  <div class="template-form px-0 mx-auto mt-0 mt-md-4 col-lg-6 daily-form">
     <div>
       <h3 class="text-light p-3">Edit Template</h3>
     </div>


### PR DESCRIPTION
Wrap up new plan styling page
Make form related classes for use on other pages

Notes:
- need to fox the hr that extends the box (padding classes are making it do something weird)